### PR TITLE
add dkms.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,6 @@
+PACKAGE_NAME="rtl8192eu"
+PACKAGE_VERSION="4.3.1.1"
+MAKE[0]="'make' -j $(nproc)"
+BUILT_MODULE_NAME[0]="8192eu"
+DEST_MODULE_LOCATION[0]="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"


### PR DESCRIPTION
So one can install it by 

```
git clone https://github.com/jeremyb31/rtl8192eu-linux-driver /usr/src/rtl8192eu-4.3.1.1
sudo dkms install rtl8192eu/4.3.1.1
```

and no need to worry about kernel upgrades.